### PR TITLE
Set NarrowPhase and BroadPhase to be 'Send'

### DIFF
--- a/src/collide/broad/mod.rs
+++ b/src/collide/broad/mod.rs
@@ -40,7 +40,7 @@ pub trait BroadCollisionData {
 /// - `ID`: id type of collision shapes
 /// - `A`: Aabb bounding box type
 ///
-pub trait BroadPhase<D>: Debug
+pub trait BroadPhase<D>: Debug + Send
 where
     D: BroadCollisionData,
 {

--- a/src/collide/broad/sweep_prune.rs
+++ b/src/collide/broad/sweep_prune.rs
@@ -60,7 +60,7 @@ where
     D::Bound: Aabb<Scalar = Real> + Discrete<D::Bound> + Debug,
     <D::Bound as Aabb>::Point: EuclideanSpace,
     <D::Bound as Aabb>::Diff: VectorSpace + ElementWise,
-    V: Variance<Point = <D::Bound as Aabb>::Point> + Debug,
+    V: Variance<Point = <D::Bound as Aabb>::Point> + Debug + Send,
 {
     fn compute(&mut self, shapes: &mut Vec<D>) -> Vec<(D::Id, D::Id)> {
         let mut pairs = Vec::<(D::Id, D::Id)>::default();

--- a/src/collide/narrow.rs
+++ b/src/collide/narrow.rs
@@ -19,7 +19,7 @@ use collide::CollisionShape;
 ///
 /// - `P`: collision primitive type
 /// - `T`: model-to-world transform type
-pub trait NarrowPhase<P, T>
+pub trait NarrowPhase<P, T>: Send
 where
     P: Primitive,
     <P::Point as EuclideanSpace>::Diff: Debug,
@@ -53,8 +53,8 @@ where
         + InnerSpace
         + Neg<Output = <P::Point as EuclideanSpace>::Diff>,
     P::Aabb: Discrete<P::Aabb> + Aabb<Scalar = Real>,
-    S: SimplexProcessor<Point = P::Point>,
-    E: EPA<Point = P::Point>,
+    S: SimplexProcessor<Point = P::Point> + Send,
+    E: EPA<Point = P::Point> + Send,
     T: Transform<P::Point>,
 {
     fn collide(


### PR DESCRIPTION
When integrating with Amethyst, NarrowPhase and BroadPhase needed to implement 'Send'.